### PR TITLE
Clean up docs for local devel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ This repository is constructed for a JavaScript application to demostrate a Deco
 - [Ember CLI](https://ember-cli.com/)
 - [PhantomJS](http://phantomjs.org/)
 
-### Installation & setup 
+### Quick installation & setup 
 
 - Fork this repository and download locally with ```git clone [YOUR REPO]```
 - CD into your js app root with ```cd decoupled-js/```
 - You will now install the required node modules with ```npm install```
 - You can serve your JS app with ```npm start``` and test at ```http://localhost:8080``` 
 
+### Additional setup and local development
+
+– To develop with this application locally, you should address the `@todo` comments in `client/config/environment.js`, such as changing the API endpoint to a local Drupal application. Note that you will need to re-run `npm install` after changing any variables in this file.
 
 ### Preview 
 

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -21,7 +21,8 @@ module.exports = function (environment) {
       }
     },
     APP: {
-      host: (process.env.api_endpoint || 'http://docroot.prod.acquia-sites.com'),  // @todo - Fill in your Drupal backend URL or local http://local.drupaldecoupled.com
+      // @todo - Fill in your Drupal backend URL, such as http://local.decoupled.com, then re-run `npm install`.
+      host: (process.env.api_endpoint || 'http://docroot.prod.acquia-sites.com'),
       oauth2TokenEndpoint: '/oauth/token',
       oauth2ClientId: '11111111-2222-3333-4444-555555555555',  // @todo - Fill in your client UUID
       // Here you can pass flags/options to your application instance


### PR DESCRIPTION
Any time you change environment variables, you have to rebuild (i.e. reinstall) the client app. This was tripping people up.